### PR TITLE
Feat:get match and post play endpoints

### DIFF
--- a/src/routes/matches.js
+++ b/src/routes/matches.js
@@ -2,9 +2,10 @@ const Router = require('koa-router');
 
 const router = new Router();
 
-router.get('matches.show', '/', async (ctx) => {
+router.get('matches.show', '/:id', async (ctx) => {
   try {
-    const match = await ctx.orm.Match.findOne(
+    const match = await ctx.orm.Match.findByPk(
+      ctx.params.id,
       {
         include: [
           { model: ctx.orm.Player, as: 'player1' },
@@ -13,20 +14,32 @@ router.get('matches.show', '/', async (ctx) => {
         ],
       },
     );
+    if (!match) {
+      ctx.throw(404);
+    }
+    const requestPlayer = await ctx.orm.Player.findByPk(ctx.request.query.id);
     const player1 = await match.getPlayer1();
     const player2 = await match.getPlayer2();
-    const currentPlayer = await match.getCurrentPlayer();
     const plays = await match.getPlays();
+    if (![player1.id, player2.id].includes(requestPlayer.id)) {
+      ctx.throw('No tienes permiso para acceder al tablero', 403);
+    }
+    const moves0 = plays.filter((play) => play.player === requestPlayer.id)
+      .map((play) => [play.dataValues.x, play.dataValues.y], []);
+    const moves1 = plays.filter((play) => play.player !== requestPlayer.id)
+      .map((play) => [play.dataValues.x, play.dataValues.y], []);
+
     ctx.body = {
-      match,
+      0: moves0,
+      1: moves1,
+      current: match.current,
+      turno: match.turno,
       player1,
       player2,
-      currentPlayer,
-      plays,
     };
   } catch (error) {
     console.log(error);
-    ctx.throw(404);
+    ctx.throw(error);
   }
 });
 

--- a/src/routes/matches.js
+++ b/src/routes/matches.js
@@ -2,7 +2,7 @@ const Router = require('koa-router');
 
 const router = new Router();
 
-router.get('matches.show', '/:id', async (ctx) => {
+router.get('matches.show', '/:id/players/:playerId', async (ctx) => {
   try {
     const match = await ctx.orm.Match.findByPk(
       ctx.params.id,
@@ -17,7 +17,7 @@ router.get('matches.show', '/:id', async (ctx) => {
     if (!match) {
       ctx.throw(404);
     }
-    const requestPlayer = await ctx.orm.Player.findByPk(ctx.request.query.player);
+    const requestPlayer = await ctx.orm.Player.findByPk(ctx.params.playerId);
     const player1 = await match.getPlayer1();
     const player2 = await match.getPlayer2();
     const plays = await match.getPlays();

--- a/src/routes/matches.js
+++ b/src/routes/matches.js
@@ -17,7 +17,7 @@ router.get('matches.show', '/:id', async (ctx) => {
     if (!match) {
       ctx.throw(404);
     }
-    const requestPlayer = await ctx.orm.Player.findByPk(ctx.request.query.id);
+    const requestPlayer = await ctx.orm.Player.findByPk(ctx.request.query.player);
     const player1 = await match.getPlayer1();
     const player2 = await match.getPlayer2();
     const plays = await match.getPlays();

--- a/src/routes/plays.js
+++ b/src/routes/plays.js
@@ -18,32 +18,39 @@ router.get('plays.show', '/', async (ctx) => {
 });
 
 router.post('plays.create', '/', async (ctx) => {
-  const match = await ctx.orm.Match.findByPk(ctx.request.body.match_id, {
-    include: [
-      {
-        model: ctx.orm.Play,
-        required: false,
-      },
-    ],
-  });
-  // construimos un array que tenga las posiciones utilizadas en formato 'x,y'
-  const plays = match.Plays.map((play) => `${play.dataValues.x}, ${play.dataValues.y}`);
-  if (![match.player_1, match.player_2].includes(ctx.request.body.player)) {
-    ctx.throw('No tienes permiso para realizar esta jugada', 403);
-  }
-  if (match.turno !== (ctx.request.body.player)) {
-    ctx.throw('No es tu turno', 403);
-  }
-  if (!(ctx.request.body.x >= 0 && ctx.request.body.x <= 2)
-  || !(ctx.request.body.y >= 0 && ctx.request.body.y <= 2)) {
-    ctx.throw('La casilla ingresada no existe', 400);
-  }
-  if (plays.includes(`${ctx.request.body.x}, ${ctx.request.body.y}`)) {
-    ctx.throw('El casillero ya ha sido utilizado en otra jugada', 400);
-  }
+  try {
+    const match = await ctx.orm.Match.findByPk(ctx.request.body.match_id, {
+      include: [
+        {
+          model: ctx.orm.Play,
+          required: false,
+        },
+      ],
+    });
+    // construimos un array que tenga las posiciones utilizadas en formato 'x,y'
+    const plays = match.Plays.map((play) => `${play.dataValues.x}, ${play.dataValues.y}`);
+    if (![match.player_1, match.player_2].includes(ctx.request.body.player)) {
+      ctx.throw('No tienes permiso para realizar esta jugada', 403);
+    }
+    if (match.current !== (ctx.request.body.player)) {
+      ctx.throw('No es tu turno', 403);
+    }
+    if (!(ctx.request.body.x >= 0 && ctx.request.body.x <= 2)
+    || !(ctx.request.body.y >= 0 && ctx.request.body.y <= 2)) {
+      ctx.throw('La casilla ingresada no existe', 400);
+    }
+    if (plays.includes(`${ctx.request.body.x}, ${ctx.request.body.y}`)) {
+      ctx.throw('El casillero ya ha sido utilizado en otra jugada', 400);
+    }
 
-  const play = await ctx.orm.Play.create(ctx.request.body);
-  ctx.throw(play.dataValues, 201);
+    const play = await ctx.orm.Play.create(ctx.request.body);
+    match.turno += 1;
+    match.current = ctx.request.body.player === match.player_1 ? match.player_2 : match.player_1;
+    match.save();
+    ctx.throw(play.dataValues, 201);
+  } catch (error) {
+    ctx.throw(error);
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## What 

- Create some endpoints: create plays and get a specific match by id.

## Why
- To create some endpoints to connect to API through frontend.
- To apply some sequelize finders.

## How
- Creating two endpoints in the router folder.

## Testing 

- Postman:

**[GET MATCH ENDPOINT]**

<img width="930" alt="image" src="https://user-images.githubusercontent.com/69643709/192168421-a07fe25e-d2d8-4cc3-966d-5dbdd6003cfe.png">
**[POST PLAY ENDPOINT]**

<img width="947" alt="image" src="https://user-images.githubusercontent.com/69643709/192167267-69409af8-1d1d-4d68-bcd0-a9f215e92278.png">


## Screenshots 
<img width="577" alt="image" src="https://user-images.githubusercontent.com/69643709/192168416-588c7ec9-5073-4683-a1da-059d2d2619ac.png">


<img width="779" alt="image" src="https://user-images.githubusercontent.com/69643709/192167408-a53a8a78-55b5-4868-9a7a-560484b40c97.png">


## Anything else? (optional)
